### PR TITLE
Update 14 dependencies

### DIFF
--- a/frontend/erp-tool/package.json
+++ b/frontend/erp-tool/package.json
@@ -13,22 +13,22 @@
     "leaflet": "^1.9.4",
     "leaflet-control-geocoder": "^3.1.0",
     "leaflet-routing-machine": "^3.2.12",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "react-leaflet": "^5.0.0"
   },
   "devDependencies": {
-    "@types/leaflet": "^1.9.8",
-    "@types/react": "^18.2.55",
-    "@types/react-dom": "^18.2.19",
-    "@vitejs/plugin-react": "^4.2.1",
-    "autoprefixer": "^10.4.17",
-    "eslint": "^8.56.0",
-    "eslint-plugin-react": "^7.33.2",
-    "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-react-refresh": "^0.4.5",
-    "postcss": "^8.4.35",
-    "tailwindcss": "^3.4.1",
-    "vite": "^5.1.0"
+    "@types/leaflet": "^1.9.17",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
+    "@vitejs/plugin-react": "^4.4.1",
+    "autoprefixer": "^10.4.21",
+    "eslint": "^9.25.1",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.20",
+    "postcss": "^8.5.3",
+    "tailwindcss": "^4.1.4",
+    "vite": "^6.3.3"
   }
 }


### PR DESCRIPTION
## Dependency Updates

This PR updates the following dependencies to their latest versions:

- `react`: ^19.0.0 → 19.1.0
- `react-dom`: ^19.0.0 → 19.1.0
- `@types/leaflet`: ^1.9.8 → 1.9.17
- `@types/react`: ^18.2.55 → 19.1.2
- `@types/react-dom`: ^18.2.19 → 19.1.2
- `@vitejs/plugin-react`: ^4.2.1 → 4.4.1
- `autoprefixer`: ^10.4.17 → 10.4.21
- `eslint`: ^8.56.0 → 9.25.1
- `eslint-plugin-react`: ^7.33.2 → 7.37.5
- `eslint-plugin-react-hooks`: ^4.6.0 → 5.2.0
- `eslint-plugin-react-refresh`: ^0.4.5 → 0.4.20
- `postcss`: ^8.4.35 → 8.5.3
- `tailwindcss`: ^3.4.1 → 4.1.4
- `vite`: ^5.1.0 → 6.3.3


---
[AUTO-GENERATED: DEPENDENCY-SCANNER]